### PR TITLE
Remove comma when parsing numbers from tweet stats

### DIFF
--- a/twitter_scraper.py
+++ b/twitter_scraper.py
@@ -26,15 +26,16 @@ def get_tweets(user, pages=25):
                 raise ValueError(
                     f'Oops! Either "{user}" does not exist or is private.')
 
+            comma = ","
             tweets = []
             for tweet in html.find('.stream-item'):
                 text = tweet.find('.tweet-text')[0].full_text
                 tweetId = tweet.find('.js-permalink')[0].attrs['data-conversation-id']
                 time = datetime.fromtimestamp(int(tweet.find('._timestamp')[0].attrs['data-time-ms'])/1000.0)
                 interactions = [x.text for x in tweet.find('.ProfileTweet-actionCount')]
-                replies = int(interactions[0].split(" ")[0])
-                retweets = int(interactions[1].split(" ")[0])
-                likes = int(interactions[2].split(" ")[0])
+                replies = int(interactions[0].split(" ")[0].replace(comma, ""))
+                retweets = int(interactions[1].split(" ")[0].replace(comma, ""))
+                likes = int(interactions[2].split(" ")[0].replace(comma, ""))
                 tweets.append({'tweetId': tweetId, 'time': time, 'text': text, 'replies': replies, 'retweets': retweets, 'likes': likes})
                 
             last_tweet = html.find('.stream-item')[-1].attrs['data-item-id']
@@ -49,3 +50,4 @@ def get_tweets(user, pages=25):
             pages += -1
 
     yield from gen_tweets(pages)
+


### PR DESCRIPTION
This PR handles the case when there are >= 1000 as content to parse for the number of `replies`, `retweets`, `likes`. 
It was needed to drop the `,` from the string before converting it to `int`. 

Example: 
```Python
In [1]: from twitter_scraper import get_tweets

In [2]: for tweet in get_tweets("JeremyClarkson", pages=1):
               print(tweet)
               break
ValueError: invalid literal for int() with base 10: '6,529'
```

With this bugfix: 
```Python
In [1]: from twitter_scraper import get_tweets

In [2]: for tweet in get_tweets("JeremyClarkson", pages=1):
               print(tweet)
               break
{'tweetId': '972880564310237184', 'time': datetime.datetime(2018, 3, 11, 19, 2, 56), 'text': "Sorry Geordie. I may have published something which is horse shit. Annoying, isn't it.", 'replies': 150, 'retweets': 403, 'likes': 6553}
```

We can see that the content is parsed fine now. 