### PR TITLE
 Deliver tweets instead of pages 

### DIFF
--- a/twitter_scraper.py
+++ b/twitter_scraper.py
@@ -36,7 +36,6 @@ def get_tweets(user, tweets=100, retweets=True, maxpages=25):
             for tweet in html.find('.stream-item'):
                 data = tweet.find('.tweet-text')
                 if len(data) > 0:
-                    found += -1
                     text = tweet.find('.tweet-text')[0].full_text
                     tweetId = tweet.find(
                         '.js-permalink')[0].attrs['data-conversation-id']
@@ -62,6 +61,7 @@ def get_tweets(user, tweets=100, retweets=True, maxpages=25):
                     photos = [photo_node.attrs['data-image-url']
                               for photo_node in tweet.find('.AdaptiveMedia-photoContainer')]
                     if retweets or orginalUserId.lower() == user.lower():
+                        found += -1
                         tweets.append({'tweetId': tweetId, 'time': time, 'user': user, 'orginaluser': orginalUserId,
                                         'text': text, 'replies': replies, 'retweets': retweets, 'likes': likes,
                                        'entries': {

--- a/twitter_scraper.py
+++ b/twitter_scraper.py
@@ -5,7 +5,7 @@ from datetime import datetime
 session = HTMLSession()
 
 
-def get_tweets(user, pages=25):
+def get_tweets(user, tweets=100, retweets=True, maxpages=25):
     """Gets tweets for a given user, via the Twitter frontend API."""
 
     url = f'https://twitter.com/i/profiles/show/{user}/timeline/tweets?include_available_features=1&include_entities=1&include_new_items_bar=true'
@@ -17,10 +17,12 @@ def get_tweets(user, pages=25):
         'X-Requested-With': 'XMLHttpRequest'
     }
 
-    def gen_tweets(pages):
+    def gen_tweets(tweets, retweets, maxpages):
         r = session.get(url, headers=headers)
+        pages = maxpages
+        found = tweets
 
-        while pages > 0:
+        while pages > 0 and found > 0:
             try:
                 html = HTML(html=r.json()['items_html'],
                             url='bunk', default_encoding='utf-8')
@@ -32,38 +34,60 @@ def get_tweets(user, pages=25):
             dot = "."
             tweets = []
             for tweet in html.find('.stream-item'):
-                text = tweet.find('.tweet-text')[0].full_text
-                tweetId = tweet.find(
-                    '.js-permalink')[0].attrs['data-conversation-id']
-                time = datetime.fromtimestamp(
-                    int(tweet.find('._timestamp')[0].attrs['data-time-ms'])/1000.0)
-                interactions = [x.text for x in tweet.find(
-                    '.ProfileTweet-actionCount')]
-                replies = int(interactions[0].split(" ")[0].replace(comma, "").replace(dot,""))
-                retweets = int(interactions[1].split(" ")[
-                               0].replace(comma, "").replace(dot,""))
-                likes = int(interactions[2].split(" ")[0].replace(comma, "").replace(dot,""))
-                hashtags = [hashtag_node.full_text for hashtag_node in tweet.find('.twitter-hashtag')]
-                urls = [url_node.attrs['data-expanded-url'] for url_node in tweet.find('a.twitter-timeline-link:not(.u-hidden)')]
-                photos = [photo_node.attrs['data-image-url'] for photo_node in tweet.find('.AdaptiveMedia-photoContainer')]
-                tweets.append({'tweetId': tweetId, 'time': time, 'text': text,
-                               'replies': replies, 'retweets': retweets, 'likes': likes, 
-                               'entries': {
-                                    'hashtags': hashtags,
-                                    'urls': urls,
-                                    'photos': photos
-                                }
-                               })
+                data = tweet.find('.tweet-text')
+                if len(data) > 0:
+                    found += -1
+                    text = tweet.find('.tweet-text')[0].full_text
+                    tweetId = tweet.find(
+                        '.js-permalink')[0].attrs['data-conversation-id']
+                    orginalUserId = tweet.find(
+                        '.js-original-tweet')[0].attrs['data-screen-name']
+                    time = datetime.fromtimestamp(
+                        int(tweet.find('._timestamp')[0].attrs['data-time-ms']) / 1000.0)
+                    interactions = [
+                        x.text for x in tweet.find('.ProfileTweet-actionCount')]
+                    replies = int(
+                        interactions[0].split(" ")[0].replace(
+                            comma, "").replace(dot, ""))
+                    retweets = int(
+                        interactions[1].split(" ")[0].replace(
+                            comma, "").replace(dot, ""))
+                    likes = int(
+                        interactions[2].split(" ")[0].replace(
+                            comma, "").replace(dot, ""))
+                    hashtags = [
+                        hashtag_node.full_text for hashtag_node in tweet.find('.twitter-hashtag')]
+                    urls = [url_node.attrs['data-expanded-url']
+                            for url_node in tweet.find('a.twitter-timeline-link:not(.u-hidden)')]
+                    photos = [photo_node.attrs['data-image-url']
+                              for photo_node in tweet.find('.AdaptiveMedia-photoContainer')]
+                    if retweets or orginalUserId.lower() == user.lower():
+                        tweets.append({'tweetId': tweetId, 'time': time, 'user': user, 'orginaluser': orginalUserId,
+                                        'text': text, 'replies': replies, 'retweets': retweets, 'likes': likes,
+                                       'entries': {
+                                           'hashtags': hashtags,
+                                           'urls': urls,
+                                           'photos': photos
+                                       }
+                                       })
 
-            last_tweet = html.find('.stream-item')[-1].attrs['data-item-id']
+            last_tweet = html.find(
+                '.stream-item')[-1].attrs['data-item-id']
 
             for tweet in tweets:
                 if tweet:
                     tweet['text'] = re.sub('http', ' http', tweet['text'], 1)
+                    remove = 'pic.twitter.com'
+                    removelen = len(remove) + 11
+                    index = tweet['text'].find(remove)
+                    while index > 0:
+                        tweet['text'] = tweet['text'][0:index] + \
+                            tweet['text'][index + removelen:]
+                        index = tweet['text'].find('pic.twitter.com')
                     yield tweet
 
             r = session.get(
-                url, params = {'max_position': last_tweet}, headers = headers)
+                url, params={'max_position': last_tweet}, headers=headers)
             pages += -1
 
-    yield from gen_tweets(pages)
+    yield from gen_tweets(tweets, retweets, maxpages)


### PR DESCRIPTION
Multiple changes:
- the function now returns the amount of tweets given (or until it runs out of pages)
- an option to include (or exclude) tweets that are retweets from other users
- a sanity check if there is a tweet-text present (it sometimes failed)
- the user id of the orginal tweet is included (orginalUserId) in the tweet data
- the requested user is included in the tweet data (usefull when lists from different users are combined together)
- references to pic.twitter.com are removed from the tweet text