### PR TITLE
Check for .tweet-text children before using them

### DIFF
--- a/twitter_scraper.py
+++ b/twitter_scraper.py
@@ -32,7 +32,10 @@ def get_tweets(user, pages=25):
             dot = "."
             tweets = []
             for tweet in html.find('.stream-item'):
-                text = tweet.find('.tweet-text')[0].full_text
+                tweet_text_elements = tweet.find('.tweet-text')
+                if not tweet_text_elements:
+                    continue
+                text = tweet_text_elements[0].full_text
                 tweetId = tweet.find(
                     '.js-permalink')[0].attrs['data-conversation-id']
                 time = datetime.fromtimestamp(


### PR DESCRIPTION
Fix for https://github.com/kennethreitz/twitter-scraper/issues/32

Idk if a `try / except IndexError` would be more readable