### PR TITLE
Force using en locale

### DIFF
--- a/twitter_scraper.py
+++ b/twitter_scraper.py
@@ -14,7 +14,8 @@ def get_tweets(user, pages=25):
         'Referer': f'https://twitter.com/{user}',
         'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/603.3.8 (KHTML, like Gecko) Version/10.1.2 Safari/603.3.8',
         'X-Twitter-Active-User': 'yes',
-        'X-Requested-With': 'XMLHttpRequest'
+        'X-Requested-With': 'XMLHttpRequest',
+        'Accept-Language': 'en-US,en;'
     }
 
     def gen_tweets(pages):


### PR DESCRIPTION
The following line:

```likes = int(interactions[2].split(" ")[0].replace(comma, "").replace(dot,""))```

caused issue when using an non-us locale (`ValueError: invalid literal for int() with base 10: '2\xa0804'`).

I solved it by forcing 'Accept-Language' header to `en`.