### PR TITLE
Restrict tweets selector to direct children only

### DIFF
--- a/twitter_scraper.py
+++ b/twitter_scraper.py
@@ -31,7 +31,7 @@ def get_tweets(user, pages=25):
             comma = ","
             dot = "."
             tweets = []
-            for tweet in html.find('.stream-item'):
+            for tweet in html.find('html > .stream-item'):
                 text = tweet.find('.tweet-text')[0].full_text
                 tweetId = tweet.find(
                     '.js-permalink')[0].attrs['data-conversation-id']


### PR DESCRIPTION
Fixes the IndexError exception when `tweet.find('.tweet-text')` is empty.
This is an alternative to #33.
