### PR TITLE
Avoid adding spaces in front of urls that already have them.

### DIFF
--- a/twitter_scraper.py
+++ b/twitter_scraper.py
@@ -106,7 +106,8 @@ def get_tweets(user, pages=25):
 
             for tweet in tweets:
                 if tweet:
-                    tweet['text'] = re.sub('http', ' http', tweet['text'], 1)
+                    tweet['text'] = re.sub(r'\Shttp', ' http', tweet['text'], 1)
+                    tweet['text'] = re.sub(r'\Spic\.twitter', ' pic.twitter', tweet['text'], 1)
                     yield tweet
 
             r = session.get(url, params={'max_position': last_tweet}, headers=headers)


### PR DESCRIPTION
A space is added in front of urls in tweet['text'] even if they already have a space, resulting in two spaces. I added a regex to avoid this and a similar one for urls starting with 'pic.twitter.com'. 