### PR TITLE
Fix tweet id mismatch/repetition.

### DIFF
--- a/twitter_scraper.py
+++ b/twitter_scraper.py
@@ -40,7 +40,7 @@ def get_tweets(user, pages=25):
                 except IndexError:  # issue #50
                     continue
 
-                tweet_id = tweet.find('.js-permalink')[0].attrs['data-conversation-id']
+                tweet_id = tweet.attrs['data-item-id']
 
                 time = datetime.fromtimestamp(int(tweet.find('._timestamp')[0].attrs['data-time-ms']) / 1000.0)
 


### PR DESCRIPTION
Some tweet IDs were being scrapped more than once, causing mismatches with tweet content. Scraping the first 'data-item-id' seems to correct the mismatching.

Before:
>>> for t in get_tweets('Yuryu', 1):
...     print(t['tweetId'])
...
1106088308428472320
**1108002717119598597
1108002717119598597**
1107915982536884224
1106088308428472320
1106088941231300608
**1107614453284171776
1107614453284171776**
1107471949020557312
1055645865384296450
**1106756329291444234
1106756329291444234**
...

After:
>>> for t in get_tweets('Yuryu', 1):
...     print(t['tweetId'])
...
1107841133378326528
1108017811345956867
1108002717119598597
1107915982536884224
1107841133378326528
1107840678673801218
1107627237942145029
1107614453284171776
1107471949020557312
1107284948275417088
1106779622299983872
1106756329291444234
...