### PR TITLE
Avoid adding spaces in front of urls that already have them.

### DIFF
--- a/twitter_scraper.py
+++ b/twitter_scraper.py
@@ -113,7 +113,8 @@ def get_tweets(user, pages=25):
 
             for tweet in tweets:
                 if tweet:
-                    tweet['text'] = re.sub('http', ' http', tweet['text'], 1)
+                    tweet['text'] = re.sub(r'\Shttp', ' http', tweet['text'], 1)
+                    tweet['text'] = re.sub(r'\Spic\.twitter', ' pic.twitter', tweet['text'], 1)
                     yield tweet
 
             r = session.get(url, params={'max_position': last_tweet}, headers=headers)


### PR DESCRIPTION
A space is added in front of urls in tweet['text'] even if they already have a space, resulting in an extra space. 

Current output (two spaces between _effect_ and _https://..._):
```
>>> for tweet in get_tweets('kennethreitz', 1):
...     print(tweet['text'])
...
Requests was used in humanity's first ever photo of a black hole!!! The butterfly is in effect  https://github.com/achael/eht-imaging/blob/9f6093a08bc37f51fab2ad1b9b3b37cda8863cb1/ehtim/imaging/dynamical_imaging.py …
```

After this fix (single space between _effect_ and _https://..._):
```
>>> for tweet in get_tweets('kennethreitz', 1):
...     print(tweet['text'])
...
Requests was used in humanity's first ever photo of a black hole!!! The butterfly is in effect https://github.com/achael/eht-imaging/blob/9f6093a08bc37f51fab2ad1b9b3b37cda8863cb1/ehtim/imaging/dynamical_imaging.py …
```
