### PR TITLE
Fix broken extraction

### DIFF
--- a/twitter_scraper.py
+++ b/twitter_scraper.py
@@ -1,6 +1,7 @@
 import re
 from requests_html import HTMLSession, HTML
 from datetime import datetime
+from lxml.etree import ParserError
 
 session = HTMLSession()
 
@@ -28,6 +29,8 @@ def get_tweets(user, pages=25):
             except KeyError:
                 raise ValueError(
                     f'Oops! Either "{user}" does not exist or is private.')
+            except ParserError:
+                break
 
             comma = ","
             dot = "."

--- a/twitter_scraper.py
+++ b/twitter_scraper.py
@@ -32,7 +32,7 @@ def get_tweets(user, pages=25):
             comma = ","
             dot = "."
             tweets = []
-            for tweet in html.find('html > .stream-item'):
+            for tweet in html.find('.stream-item'):
                 # 10~11 html elements have `.stream-item` class and also their `data-item-type` is `tweet`
                 # but their content doesn't look like a tweet's content
                 try:


### PR DESCRIPTION
Extraction is currently broken.

```
>>> for tweet in get_tweets('kennethreitz', 1):
...     print(tweet['text'])
...
>>>
```



After taking out `html >`, it works:

```
>>> for tweet in get_tweets('kennethreitz', 1):
...     print(tweet['text'])
...
Requests was used in humanity's first ever photo of a black hole!!! The butterfly is in effect  https://github.com/achael/eht-imaging/blob/9f6093a08bc37f51fab2ad1b9b3b37cda8863cb1/ehtim/imaging/dynamical_imaging.py …
 https://www.instagram.com/kennethreitz/p/BzAnQvopuMx/ …pic.twitter.com/cYvtOKIL7A
...
```

In addition to this, if number of specified pages is more than the number of tweets available, a ParserError will occur. To avoid this, I added a `break` statement when this exception is caught, ending extraction when tweets data is no longer available.